### PR TITLE
fix find accented when diphthong

### DIFF
--- a/src/pylabeador/syllabify.py
+++ b/src/pylabeador/syllabify.py
@@ -148,6 +148,7 @@ def nucleus(word: WordProgress):
 
         # The previous is closed
         if second_vowel.has_accent:
+            word.accent = word.pos
             word.stress_found = True
         word.next()
 

--- a/test/test_hyphenation_and_stress.py
+++ b/test/test_hyphenation_and_stress.py
@@ -46,12 +46,18 @@ def test_hyphenation_of_common_words(word, hyphenated, stressed):
     assert res.stressed == stressed
 
 
-@parametrize_with_words_from([
-    ('Actuáis', 'Ac-tuáis', 2),
-    ('Desagüe', 'De-sa-güe', 2),
-    ('fugu', 'fu-gu', 1),
-])
-def test_special_words(word, hyphenated, stressed):
+@pytest.mark.parametrize(
+    'word, hyphenated, stressed, accented',
+    [
+        ('Actuáis', 'Ac-tuáis', 2, 4),
+        ('Construcción', 'Cons-truc-ción', 3, 10),
+        ('Melón', 'Me-lón', 2, 3),
+        ('Desagüe', 'De-sa-güe', 2, None),
+        ('fugu', 'fu-gu', 1, None),
+    ]
+)
+def test_special_words(word, hyphenated, stressed, accented):
     res = syllabify_with_details(word)
     assert res.hyphenated == hyphenated
     assert res.stressed == stressed
+    assert res.accented == accented


### PR DESCRIPTION
I think there is a problem when pylabeador deals with a dyphthong with accented vowel.

For instance:

```python
from pylabeador import syllabify_with_details                                               

word = syllabify_with_details("construcción")                                               
print(word.accented)
```
I think previous code should return `10` instead of `None`.

The PR tries to fix this.